### PR TITLE
Revert temporary fix for random log outs

### DIFF
--- a/security.py
+++ b/security.py
@@ -240,11 +240,6 @@ def create_user_token(username: str, ip: str, used_token: Optional[str] = None) 
             "content": "Your account was scheduled for deletion but you logged back in. Your account is no longer scheduled for deletion! If you didn't request for your account to be deleted, please change your password immediately."
         }))
     
-    # Return original token if one is specified
-    # This is a temporary fix for people being randomly logged out
-    if used_token:
-    	return used_token
-    
     # Generate new token, revoke used token, and update last seen timestamp
     new_token = secrets.token_urlsafe(TOKEN_BYTES)
     account["tokens"].append(new_token)


### PR DESCRIPTION
this change broke meower, you can't log in anymore

user logs in with username and password -> server attempts to create a new token to give to user -> temporary fix causes it to return the token the user used -> server returns their password as the token, user is not authorized
